### PR TITLE
Ignore New Header for API Keys

### DIFF
--- a/harbor_wave.py
+++ b/harbor_wave.py
@@ -154,9 +154,12 @@ def warn(message):
 
 def check_api_key(key):
     '''checks if API key is valid format. returns True/False. Takes one parameter, the key'''
-    # a DO access key is 64 characters long, hexidecimal
+    # a DO access key is 64 characters long, hexidecimal, new format has
+    # meta headers before the hexdec
     key_len = 64
     base    = 16
+    # Strip headers, if present
+    key = key.split('_')[-1]
     # Key is a string
     if type(key) != str:
         return False


### PR DESCRIPTION
New DO API keys added a header that starts with dop_v1_ before the 64 character hexdec key. Added check to ignore this when setting API key