### PR TITLE
Add project to bash completion for set/get

### DIFF
--- a/bash-completion/harbor-wave
+++ b/bash-completion/harbor-wave
@@ -5,7 +5,7 @@ _harborwave_completion(){
   local base_commands="spawn destroy list get set help print-config touch check-config"
   local help_topics="config commands"
   local list_commands="machines templates regions ssh-keys sizes domains money-left projects"
-  local config_items="api-key domain region ssh-key-n tag base-name size template wait"
+  local config_items="api-key domain region ssh-key-n tag base-name size template wait project"
   cur=${COMP_WORDS[COMP_CWORD]}
   prev=${COMP_WORDS[COMP_CWORD-1]}
 


### PR DESCRIPTION
Fixed it for list last bugfix release.

"project" now specifies digital ocean "project" folder to put new droplets used with spawn. tab completion with bash now lists this with harborwave set|get