### PR TITLE
added --terse/-T support for destroy

### DIFF
--- a/man/harbor-wave.1
+++ b/man/harbor-wave.1
@@ -188,6 +188,9 @@ headers, but the tab seperated columns are replaced by commas.
 For spawn, all printing is surpressed except errors and warns that got to STDERR
 and it returns a comma seperated list of NAME:IP of machines spawned i.e.
 
+For destroy, it returns a comma seperated list of names of machines to be
+destroyed
+
 host1:127.45.67.89,host2:127.23.45.67
 
 .SS CONFIG OVERRIDE OPTIONS


### PR DESCRIPTION
--terse/-T option now works with the destroy command.

destroy with --terse just returns a comma separated list of machines destroyed to STDOUT, and any errors and warns get printed to STDERR